### PR TITLE
azure-mgmt-containerservice 41.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "azure-mgmt-containerservice" %}
-{% set version = "41.1.0" %}
+{% set version = "41.0.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 7ecb2e63e87366012fda7c13d36baff6a2aa599fc679252a29607633ed186ca8
+  sha256: 9830d0a42730609c97a133a913e2caffbd163d4d3ff315afc3a76728222a3f61
 
 build:
   number: 0


### PR DESCRIPTION
azure-mgmt-containerservice 41.0.0

**Destination channel:** defaults

### Links

- [PKG-14473](https://anaconda.atlassian.net/browse/PKG-14473) 
- [Upstream repository](https://inspector.pypi.io/project/azure-mgmt-containerservice/41.0.0/packages/0d/d5/77c8345ba10e72d02e4abae8ce50ecba417fcffcc4c3bbb226134bc5b69a/azure_mgmt_containerservice-41.0.0.tar.gz/azure_mgmt_containerservice-41.0.0/pyproject.toml)

### Explanation of changes:

- rebuild: I initially chose the wrong version


[PKG-14473]: https://anaconda.atlassian.net/browse/PKG-14473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ